### PR TITLE
Initial draft of a set of scripts to create DataLad datasets for individual participants

### DIFF
--- a/code/ukb_create_participant_ds
+++ b/code/ukb_create_participant_ds
@@ -23,8 +23,29 @@ participant_id=$2
 shift;shift;
 datarecords=$@
 
+# create plain dataset
 datalad create "$dspath"
+
+cd "$dspath"
+
+# establish "incoming" branch that will hold pristine UKB downloads
+git checkout --orphan incoming
+# place batch file with download config for ukbfetch in it
 for d in $datarecords; do
-	echo "$participant_id $d" >> "$dspath/.ukbbatch"
+	echo "$participant_id $d" >> ".ukbbatch"
 done
-datalad save -d "$dspath" --to-git -m "Add UKB data fetch configuration" "$dspath/.ukbbatch"
+# save to incoming branch, provide path to avoid adding untracked content
+# (due to --orphan above)
+datalad save --to-git -m "Add UKB data fetch configuration" ".ukbbatch"
+# establish rest of the branch structure: "incoming-processsed" for extracted
+# archive content
+git checkout -b incoming-processed incoming
+# wipe out batch file to keep download-related info separate
+git rm .ukbbatch
+git commit -m "Do not leak ukbfetch configuration into dataset content" .ukbbatch
+# force merge unrelated histories into master
+# we are using an orphan branch such that we know that `git ls-tree incoming`
+# will only report download-related content, nothing extracted or manually
+# modified
+git checkout master
+git merge -m "Merge incoming branch" --allow-unrelated-histories incoming-processed

--- a/code/ukb_create_participant_ds
+++ b/code/ukb_create_participant_ds
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Create a DataLad dataset for a UKbiobank participant
+#
+# This script takes a minimum of three positional arguments:
+#
+# 1. Path where the dataset shall be created. It must not exist or be an empty
+#    directory.
+# 2. The "encoded ID" of the target participant
+# 3. One (or more) data record IDs
+#
+# A batch file for the `ukbfetch` tool will be generated and placed into the dataset.
+# By selecting the relevant data records, raw and/or preprocessed data will be tracked.
+#
+# Example:
+#
+#  ukb_create_participant_ds ukb_preprocessed/58453415 5874415 20227_2_0 20249_2_0
+#
+
+set -e -u
+
+dspath=$1
+participant_id=$2
+shift;shift;
+datarecords=$@
+
+datalad create "$dspath"
+for d in $datarecords; do
+	echo "$participant_id $d" >> "$dspath/.ukbbatch"
+done
+datalad save -d "$dspath" --to-git -m "Add UKB data fetch configuration" "$dspath/.ukbbatch"

--- a/code/ukb_update_participant_ds
+++ b/code/ukb_update_participant_ds
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Update an existing dataset of a UKbiobank participant
+#
+# This script expects a preconfigured DataLad dataset as created by
+# `ukb_create_participant_ds`. It takes two mandatory positional arguments:
+#
+# 1. Path to the dataset to be updated
+# 2. Path to a UKB keyfile for authorizing the download
+#
+# The dataset may or may not have any downloaded content already.
+#
+set -e -u
+
+dspath="$1"
+keyfile="$(readlink -f "$2")"
+
+cd "$dspath"
+
+oldbranch="$(git rev-parse --abbrev-ref HEAD)"
+
+# make sure we are in incoming whether or not the branch existed
+git checkout -b incoming || git checkout incoming
+
+# record current state
+oldcommit=$(git rev-parse incoming)
+
+# download stage, fake for now
+mkdir -p .git/tmp/ukb
+datalad run -m "Update from UKbiobank" --output . ukbfetch -v -a"$keyfile" -b.ukbbatch -o.git/tmp/ukb/fetched.ls
+
+# stop here, if run made no commit
+[ "$oldcommit" = "$(git rev-parse incoming)" ] && git checkout $oldbranch && exit 0
+
+# make sure we are in incoming-processed whether or not the branch existed
+git checkout -b incoming-processed master || git checkout incoming-processed
+
+# figure out the keys of any files that the last commit added/changed
+# 
+for f in $(datalad -f json diff -f incoming^ -t incoming | jq '. | select(.state == "added", .state == "modified") | .path' | tr -d '"'); do 
+	# --use-current-dir due to https://github.com/datalad/datalad/issues/3995
+	datalad add-archive-content \
+		--use-current-dir \
+		--allow-dirty \
+		--no-commit \
+		--key $(basename $(git cat-file -p "incoming:$(basename $f)"))
+done
+datalad save -m "Track ZIP file content"
+
+# and update user-facing branch
+git checkout master
+git merge incoming-processed
+
+# be nice
+git checkout $oldbranch

--- a/code/ukb_update_participant_ds
+++ b/code/ukb_update_participant_ds
@@ -14,41 +14,68 @@ set -e -u
 dspath="$1"
 keyfile="$(readlink -f "$2")"
 
+# it is critical that the rest of the script runs in the dataset
+# we are doing an `rm -f` below !!!
 cd "$dspath"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Refuse to operate on dirty dataset"
+  exit 1
+fi
 
 oldbranch="$(git rev-parse --abbrev-ref HEAD)"
 
 # make sure we are in incoming whether or not the branch existed
-git checkout -b incoming || git checkout incoming
+git checkout incoming
 
 # record current state
 oldcommit=$(git rev-parse incoming)
 
-# download stage, fake for now
+# download stage
 mkdir -p .git/tmp/ukb
-datalad run -m "Update from UKbiobank" --output . ukbfetch -v -a"$keyfile" -b.ukbbatch -o.git/tmp/ukb/fetched.ls
+# first wipe out all prev. downloaded zip files so we could detect
+# when some files are no longer available
+rm -f *.zip
+# redownload, run with explicit mode, because we just deleted the ZIP files
+# and that is OK
+datalad run --explicit --output . -m "Update from UKbiobank" ukbfetch -v -a"$keyfile" -b.ukbbatch -o.git/tmp/ukb/fetched.ls
 
 # stop here, if run made no commit
 [ "$oldcommit" = "$(git rev-parse incoming)" ] && git checkout $oldbranch && exit 0
 
-# make sure we are in incoming-processed whether or not the branch existed
-git checkout -b incoming-processed master || git checkout incoming-processed
+# update extracted content branch
+git checkout incoming-processed
 
-# figure out the keys of any files that the last commit added/changed
-# 
-for f in $(datalad -f json diff -f incoming^ -t incoming | jq '. | select(.state == "added", .state == "modified") | .path' | tr -d '"'); do 
+# mark the incoming change as merged (but we do not actually want any branch content)
+git merge -m "Merge incoming" --strategy=ours incoming
+
+# wipe out the branch content, because we want to start from clean slate every time
+# give full branch name to make more robust
+[ -n "$(git ls-tree --name-only --full-name incoming-processed)" ] && git ls-tree --name-only --full-name incoming-processed -z -r | xargs -0 rm -f
+
+# discover all files present in the last commit in 'incoming'
+# (diff will also report on clean files). These should all be ZIP files.
+# We know that ZIP files can not only be added by the logic above, hence
+# we need to filter out deletions
+for f in $(datalad -f json diff -f incoming^ -t incoming | jq '. | select(.state == "added", .state == "modified", .state != "deleted") | .path' | tr -d '"'); do
+	f=$(basename $f)
+	# the space in the expression below is a feature
+	[ "${f: -4}" != ".zip" ] && continue || true
 	# --use-current-dir due to https://github.com/datalad/datalad/issues/3995
 	datalad add-archive-content \
 		--use-current-dir \
 		--allow-dirty \
 		--no-commit \
-		--key $(basename $(git cat-file -p "incoming:$(basename $f)"))
+		--key $(basename $(git cat-file -p "incoming:$f"))
 done
+
+# save whatever the state is now, `save` will discover deletions automatically
+# and also commit them -- wonderful!
 datalad save -m "Track ZIP file content"
 
 # and update user-facing branch
 git checkout master
-git merge incoming-processed
+git merge -m "Merge update from UKbiobank" incoming-processed
 
 # be nice
 git checkout $oldbranch


### PR DESCRIPTION
The generated dataset will be similar to the standard setup produced by the DataLad crawler: three branches:

- `incoming`: Tracks the pristine ZIP files downloaded from UKB
- `incoming-processed`: extracted ZIP file content
- `master`: based on incoming-processed with potential modifications
          applied

TODO:

- [x] remove previous content in incoming-processed before extracting ZIP file content when updating